### PR TITLE
Remove deep linking configuration for www.diqt.net

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,17 +20,6 @@
             android:windowSoftInputMode="adjustResize">
             <!-- flutter local notifications 参考： https://zenn.dev/tomon9086/articles/d2624f6ab37c4c -->
 
-            <!-- Deep Linking Configuration: Enables the app to handle https://www.diqt.net/* URLs
-                when clicked in browsers or other apps. App Links verification is enabled for 
-                secure deep linking functionality. -->
-            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="www.diqt.net" android:pathPattern=".*" />
-            </intent-filter>
-
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -89,7 +89,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>FlutterDeepLinkingEnabled</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -8,9 +8,5 @@
 	<array>
 		<string>Default</string>
 	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:www.diqt.net</string>
-	</array>
 </dict>
 </plist>

--- a/ios/Runner/RunnerDebug.entitlements
+++ b/ios/Runner/RunnerDebug.entitlements
@@ -8,9 +8,5 @@
 	<array>
 		<string>Default</string>
 	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:www.diqt.net</string>
-	</array>
 </dict>
 </plist>

--- a/ios/Runner/RunnerRelease.entitlements
+++ b/ios/Runner/RunnerRelease.entitlements
@@ -8,9 +8,5 @@
 	<array>
 		<string>Default</string>
 	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:www.diqt.net</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
close #761 
プルリク #738 で実装した、 "www.diqt.net"でアプリに遷移する機能を削除。
・#764 の一部にあたる